### PR TITLE
Fix/avfasset reader usage (avoid deadlock when seeking on local file)

### DIFF
--- a/AudioPlayer/Source/Gstreamer/GstreamerConfiguration.h
+++ b/AudioPlayer/Source/Gstreamer/GstreamerConfiguration.h
@@ -5,6 +5,17 @@
 
 G_BEGIN_DECLS
 
+/*
+ * Wether to use avfassetsrc to access local files on iOS
+ * (this is wrapping AVFAssetReader API that reads and
+ * decodes samples from media files on iOS, they get piped into playsink as raw samples)
+ *
+ * There is a deadlock observed when using the element, and we haven't seen any
+ * issue with using filesrc instead. The performance may be impacted however, since we
+ * are doing more things in the user-space that may be done in kernel when using AVFAssetReader API.
+ */
+#define USE_AVFASSETSRC FALSE
+
 #define GST_G_IO_MODULE_DECLARE(name) \
 extern void G_PASTE(g_io_module_, G_PASTE(name, _load_static)) (void)
 

--- a/AudioPlayer/Source/Gstreamer/GstreamerConfiguration.m
+++ b/AudioPlayer/Source/Gstreamer/GstreamerConfiguration.m
@@ -1022,6 +1022,7 @@ void GstreamerConfiguration (void)
     GST_G_IO_MODULE_LOAD(gnutls);
 #endif
     
+#if USE_AVFASSETSRC
     /* Lower the ranks of filesrc and giosrc so iosavassetsrc is
      * tried first in gst_element_make_from_uri() for file:// */
     reg = gst_registry_get();
@@ -1031,4 +1032,5 @@ void GstreamerConfiguration (void)
     plugin = gst_registry_lookup_feature(reg, "giosrc");
     if (plugin)
         gst_plugin_feature_set_rank(plugin, GST_RANK_SECONDARY-1);
+#endif
 }


### PR DESCRIPTION
Fixes seeking on `file://...` resources. Makes sure we use `filesrc` (generic file access) instead of `avfassetsrc` (iOS-specific media-file-decoder component using AVAssetReader)

TODO (but not needed for merging this):

- [ ] File a bug to GStreamer about deadlock when seeking on `avfassetsrc`

- [ ] Investigate the side-effects of using `filesrc` over `avfassetsrc` (may have performance overhead)

This solution will work now and doesn't cause any problems afaics. If there isn't more than a theoretical performance overhead involved we can safely use filesrc. If we think we need avfassetsrc we should try to fix the bug there causing the deadlock on seeking. That would also be the nicer long-term solution imo (as it is always preferable to optimize resource usage on iOS, and using filesrc may have other unknown ramifications).