### PR TITLE
sane framework installation

### DIFF
--- a/AudioPlayer/AudioPlayer.xcodeproj/project.pbxproj
+++ b/AudioPlayer/AudioPlayer.xcodeproj/project.pbxproj
@@ -107,7 +107,7 @@
 		DA50C11420F8ABF800E2E12C /* Gstreamer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Gstreamer.m; sourceTree = "<group>"; };
 		DA50C11520F8ABF800E2E12C /* GstreamerConfiguration.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GstreamerConfiguration.m; sourceTree = "<group>"; };
 		DA53E8F620E2627700CE899D /* libiconv.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libiconv.tbd; path = usr/lib/libiconv.tbd; sourceTree = SDKROOT; };
-		DA606AFE20E130D2003C6EFB /* GStreamer.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = GStreamer.framework; path = "$(USER_LIBRARY_DIR)/Developer/GStreamer/iPhone.sdk/GStreamer.framework"; sourceTree = "<group>"; };
+		DA606AFE20E130D2003C6EFB /* GStreamer.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = GStreamer.framework; sourceTree = "<group>"; };
 		DAE8F30720F8ACFC00EE1B0C /* StateProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StateProtocol.swift; sourceTree = "<group>"; };
 		DAE8F30920F8AD3C00EE1B0C /* State.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = State.swift; sourceTree = "<group>"; };
 		DAE8F30B20F8ADE300EE1B0C /* StateStopped.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StateStopped.swift; sourceTree = "<group>"; };
@@ -632,10 +632,10 @@
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				FRAMEWORK_SEARCH_PATHS = (
-					"$(USER_LIBRARY_DIR)/Developer/GStreamer/iPhone.sdk",
+					"$(SRCROOT)/Frameworks",
 					"$(DEVELOPER_FRAMEWORKS_DIR)",
 				);
-				HEADER_SEARCH_PATHS = "\"$(USER_LIBRARY_DIR)/Developer/GStreamer/iPhone.sdk/GStreamer.framework/Headers\"";
+				HEADER_SEARCH_PATHS = "\"$(SRCROOT)/Frameworks/GStreamer.framework/Headers\"";
 				INFOPLIST_FILE = Configuration/source.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -663,10 +663,10 @@
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				FRAMEWORK_SEARCH_PATHS = (
-					"$(USER_LIBRARY_DIR)/Developer/GStreamer/iPhone.sdk",
+					"$(SRCROOT)/Frameworks",
 					"$(DEVELOPER_FRAMEWORKS_DIR)",
 				);
-				HEADER_SEARCH_PATHS = "\"$(USER_LIBRARY_DIR)/Developer/GStreamer/iPhone.sdk/GStreamer.framework/Headers\"";
+				HEADER_SEARCH_PATHS = "\"$(SRCROOT)/Frameworks/GStreamer.framework/Headers\"";
 				INFOPLIST_FILE = Configuration/source.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/README.md
+++ b/README.md
@@ -2,3 +2,6 @@
 Blinkist iOS Audio Player
 
 [![Build Status](https://app.bitrise.io/app/6ef26398a52b65be/status.svg?token=sHBQc1T-oRBkTiRZdpbozQ)](https://app.bitrise.io/app/6ef26398a52b65be)
+
+
+To get started, run `scripts/download_gstreamer_framework.sh`

--- a/scripts/download_gstreamer_framework.sh
+++ b/scripts/download_gstreamer_framework.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+VERSION=1.14.2
+
+SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
+
+mkdir -p $SCRIPTPATH/../AudioPlayer/Frameworks
+cd $SCRIPTPATH/../AudioPlayer/Frameworks/
+TARGETPATH=`pwd`
+
+cd $TMPDIR
+
+echo "📥 Downloading GStreamer $VERSION package"
+curl https://gstreamer.freedesktop.org/data/pkg/ios/$VERSION/gstreamer-1.0-devel-$VERSION-ios-universal.pkg -o ./gstreamer.pkg
+
+echo "📦 Extracting package"
+pkgutil --expand ./gstreamer.pkg ./extracted
+
+echo "📦📦 Extracting Payload of package within package"
+tar xf ./extracted/ios-framework-$VERSION-universal.pkg/Payload -C $TARGETPATH
+
+echo "✨ Cleaning up"
+rm $TMPDIR/gstreamer.pkg
+rm -rf $TMPDIR/extracted
+
+rm -rf $TARGETPATH/Templates
+
+
+echo "🍻 The framework is located at $TARGETPATH/GStreamer.framework"

--- a/scripts/download_gstreamer_framework.sh
+++ b/scripts/download_gstreamer_framework.sh
@@ -8,6 +8,23 @@ mkdir -p $SCRIPTPATH/../AudioPlayer/Frameworks
 cd $SCRIPTPATH/../AudioPlayer/Frameworks/
 TARGETPATH=`pwd`
 
+# Check if framework is already installed
+
+if [ -e $TARGETPATH/Gstreamer.framework/Resources/Info.plist ]; then
+    INSTALLED_VERSION=$(/usr/libexec/PlistBuddy -c "Print CFBundleShortVersionString" "$TARGETPATH/Gstreamer.framework/Resources/Info.plist")
+
+    if [ "$INSTALLED_VERSION" = "$VERSION" ]; then
+      echo "🍻 Version $VERSION already installed at $TARGETPATH/GStreamer.framework"
+      exit
+    else
+      echo "❌ Version $INSTALLED_VERSION already installed at $TARGETPATH/GStreamer.framework"
+      echo "Please delete the framework and run this script again to install $VERSION!"
+      exit 1
+    fi
+fi
+
+# Download framework
+
 cd $TMPDIR
 
 echo "📥 Downloading GStreamer $VERSION package"


### PR DESCRIPTION
This adds a script which downloads and extracts the `GStreamer.framework` so that a manual installation of the `.pkg` and referencing a user's Library path is not necessary anymore. 

This also shows that we could just commit the framework (currently `.gitignore`d), maybe via Git LFS, and there is no manual installation necessary.

I verified it on another developers machine that they were able to build and run the Demo app after executing the script.